### PR TITLE
fix: workbench editor does not show highlighting

### DIFF
--- a/themes/monokai-dark-soda.tmTheme
+++ b/themes/monokai-dark-soda.tmTheme
@@ -690,6 +690,17 @@
                 <string>#F8F8F2</string>
             </dict>
         </dict>
+	 <dict>
+            <key>name</key>
+            <string>Highlighting colour when used in inputs</string>
+            <key>scope</key>
+            <string>input.background</string>
+            <key>settings</key>
+            <dict>
+                <key>foreground</key>
+                <string>#242424</string>
+            </dict>
+        </dict>
     </array>
     <key>uuid</key>
     <string>233F0694-0B9C-43E3-A44A-ECECF7DF6C73</string>


### PR DESCRIPTION
Fixed foreground and highlight colors in non-workbench text editors for #242424